### PR TITLE
update KDE mirror list

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2014-06-20	Hanspeter Niederstrasser	<nieder@users.sourceforge.net>
+
+	* Updated KDE mirrors
+	  ftp://ftp.kde.org is not the upstream supported primary address
+
 2014-04-16	Alexander Hansen  <alexkhansen@users.sourceforge.net>
 
 	* Refreshed apache, cpan, ctan, freebsd, gimp, gnu, kde, and sourceforge

--- a/get-mirrors.pl
+++ b/get-mirrors.pl
@@ -75,7 +75,7 @@ my %mirror_sites = (
 	'Gimp'        => [ \&parse_gimp, 'http://www.gimp.org/downloads', 'ftp://ftp.gimp.org/pub/gimp' ],
 	'GNOME'       => [ \&parse_gnome, 'http://ftp.gnome.org/pub/GNOME/MIRRORS', 'ftp://ftp.gnome.org/pub/GNOME' ],
 	'GNU'         => [ \&parse_gnu, 'http://www.gnu.org/prep/ftp.html', 'ftp://ftpmirror.gnu.org' ],
-	'KDE'         => [ \&parse_kde, 'http://files.kde.org/extra/mirrors.html', 'ftp://ftp.kde.org/pub/kde' ],
+	'KDE'         => [ \&parse_kde, 'http://files.kde.org/extra/mirrors.html', 'http://download.kde.org/' ],
 	# FIXME: Format changed, they now only list redirect URls
 #	'PostgreSQL'  => [ \&parse_postgresql, 'http://wwwmaster.postgresql.org/download/mirrors-ftp?file=%2F', 'ftp://ftp.postgresql.org/pub' ],
 	'SourceForge' => [ \&parse_sourceforge, 'http://sourceforge.net/apps/trac/sourceforge/wiki/Mirrors','http://downloads.sourceforge.net'],

--- a/kde
+++ b/kde
@@ -1,7 +1,7 @@
 # Official mirror list: http://files.kde.org/extra/mirrors.html
-Timestamp: 2014-04-14
+Timestamp: 2014-06-20
 
-Primary: ftp://ftp.kde.org/pub/kde
+Primary: http://download.kde.org/
 
 afr-ZA: ftp://ftp.is.co.za/mirror/ftp.kde.org
 afr-ZA: http://ftp.is.co.za/mirror/ftp.kde.org
@@ -18,16 +18,14 @@ aus-AU: http://kde.mirror.uber.com.au
 eur-BE: http://kde.cu.be
 eur-CZ: ftp://ftp.fi.muni.cz/pub/kde
 eur-CZ: ftp://mirror.karneval.cz/pub/kde
-eur-CZ: ftp://mirror.oss.maxcdn.com/kde
 eur-CZ: http://ftp.fi.muni.cz/pub/kde
 eur-CZ: http://mirror.karneval.cz/pub/kde
-eur-CZ: http://mirror.oss.maxcdn.com/kde
 eur-DE: ftp://ftp-stud.fht-esslingen.de/pub/Mirrors/ftp.kde.org/pub/kde
-eur-DE: ftp://ftp.kde.org/pub/kde
 eur-DE: ftp://ftp.rz.uni-wuerzburg.de/pub/unix/kde
 eur-DE: ftp://ftp5.gwdg.de/pub/linux/kde
 eur-DE: ftp://mirror.netcologne.de/kde
 eur-DE: ftp://vesta.informatik.rwth-aachen.de/pub/mirror/kde
+eur-DE: http://download.kde.org
 eur-DE: http://ftp-stud.fht-esslingen.de/Mirrors/ftp.kde.org/pub/kde
 eur-DE: http://ftp.rz.uni-wuerzburg.de/pub/unix/kde
 eur-DE: http://ftp5.gwdg.de/pub/linux/kde
@@ -56,9 +54,11 @@ eur-PL: ftp://ftp.piotrkosoft.net/pub/mirrors/ftp.kde.org
 eur-PL: http://ftp.icm.edu.pl/pub/unix/kde
 eur-PL: http://ftp.pbone.net/pub/kde
 eur-PL: http://piotrkosoft.net/pub/mirrors/ftp.kde.org
+eur-PT: ftp://mirrors.fe.up.pt/pub/kde
 eur-PT: http://mirrors.fe.up.pt/pub/kde
 eur-SE: ftp://archive.sunet.se/pub/X11/kde
 eur-SE: http://archive.sunet.se/pub/X11/kde
+eur-UA: ftp://kde.ip-connect.vn.ua/mirror/kde
 eur-UA: http://kde.ip-connect.vn.ua
 eur-UK: ftp://ftp.mirrorservice.org/sites/ftp.kde.org/pub/kde
 eur-UK: ftp://kde.mirror.anlx.net


### PR DESCRIPTION
ftp://ftp.kde.org is not an official primary
