### PR TITLE
Cran

### DIFF
--- a/_list
+++ b/_list
@@ -9,6 +9,7 @@ Order: master rsync apt gnu gnome gimp ctan cpan debian freebsd kde sourceforge 
 master: Master Fink mirrors
 apt: Apt-Get Repository
 cpan: Comprehensive Perl Archive Network
+cran: Comprehensive R Archive Network
 ctan: Comprehensive TeX Archive Network
 debian: Debian
 freebsd: FreeBSD

--- a/cran
+++ b/cran
@@ -1,0 +1,6 @@
+# Cran has internal redirects to mirrors. We only want to point to primary and 
+# archive site.
+Timestamp: 2017-08-24
+
+Primary: https://cran.r-project.org/src/contrib
+Secondary: https://cran.r-project.org/src/contrib/Archive

--- a/inject.pl
+++ b/inject.pl
@@ -45,7 +45,7 @@ foreach $file (qw(NEWS _keys _list)) {
 }
 
 my $packagefiles = "COPYING NEWS README README.contacts install.sh postinstall.pl.in " .
-    "_keys _list _urls anonymous-cvs apache apt cpan ctan cvs-repository debian developer-cvs freebsd gimp gnome gnu kde master postgresql rsync sourceforge website" ;
+    "_keys _list _urls anonymous-cvs apache apt cpan cran ctan cvs-repository debian developer-cvs freebsd gimp gnome gnu kde master postgresql rsync sourceforge website" ;
 
 my $info_script = "";
 

--- a/install.sh
+++ b/install.sh
@@ -45,7 +45,7 @@ done
 
 echo "Copying files..."
 
-for file in ChangeLog _keys _list apache apt cpan ctan debian freebsd gimp gnome gnu kde master postgresql rsync sourceforge; do
+for file in ChangeLog _keys _list apache apt cpan cran ctan debian freebsd gimp gnome gnu kde master postgresql rsync sourceforge; do
   if [ -f $file ]; then
     install -c -p -m 644 $file "$basepath/lib/fink/mirror/"
   fi


### PR DESCRIPTION
Adds cran to the list of mirrors. We don't actually want to use the full set of mirrors since they automatically redirect in the background. Cran constantly updates packages and sends old versions to /Archive, often before our mirrors can grab the source. So this way we can search both the primary and Archive directories without having to update a .info (if using `mirror: cran` in Source:)

I have not touched either NEWS or VERSION since I'm not sure what the format there needs to be.