### PR TITLE
master: remove ber.de.eu

### DIFF
--- a/master
+++ b/master
@@ -2,6 +2,6 @@ Timestamp: 2016-02-12
 Primary: http://distfiles.master.finkmirrors.net/distfiles/
 
 asi-JP: http://distfiles.hnd.jp.asi.finkmirrors.net/
-eur-DE: http://distfiles.ber.de.eu.finkmirrors.net/
+# eur-DE: http://distfiles.ber.de.eu.finkmirrors.net/
 # eur-IE: http://distfiles.dub.ie.eu.finkmirrors.net/
 nam-CA: http://distfiles.yeg.ab.ca.finkmirrors.net/distfiles/

--- a/master
+++ b/master
@@ -1,4 +1,4 @@
-Timestamp: 2016-02-12
+Timestamp: 2023-09-27
 Primary: http://distfiles.master.finkmirrors.net/distfiles/
 
 asi-JP: http://distfiles.hnd.jp.asi.finkmirrors.net/


### PR DESCRIPTION
Gecko2's old mirror has long been inactive. We shouldn't keep listing it as available.